### PR TITLE
Update jquery.ui.touch-punch.js create simulateEvent by MouseEvent() Constructor.

### DIFF
--- a/jquery.ui.touch-punch.js
+++ b/jquery.ui.touch-punch.js
@@ -1,4 +1,6 @@
 /*!
+ *  New version 1.0.1
+ *
  * jQuery UI Touch Punch 0.2.3
  *
  * Copyright 2011–2014, Dave Furfero
@@ -38,25 +40,16 @@
     event.preventDefault();
 
     var touch = event.originalEvent.changedTouches[0],
-        simulatedEvent = document.createEvent('MouseEvents');
-    
-    // Initialize the simulated mouse event using the touch event's coordinates
-    simulatedEvent.initMouseEvent(
-      simulatedType,    // type
-      true,             // bubbles                    
-      true,             // cancelable                 
-      window,           // view                       
-      1,                // detail                     
-      touch.screenX,    // screenX                    
-      touch.screenY,    // screenY                    
-      touch.clientX,    // clientX                    
-      touch.clientY,    // clientY                    
-      false,            // ctrlKey                    
-      false,            // altKey                     
-      false,            // shiftKey                   
-      false,            // metaKey                    
-      0,                // button                     
-      null              // relatedTarget              
+    //Create the simulate mouse event using touch events coordinate
+    simulatedEvent = new MouseEvent( simulatedType,  {
+        view: window,
+        bubbles: true,
+        cancelable: true,
+        screenX: touch.screenX,
+        screenY: touch.screenX,
+        clientX: touch.clientX,
+        clientY: touch.clientY
+      }
     );
 
     // Dispatch the simulated event to the target element
@@ -145,7 +138,7 @@
    * original mouse event handling methods.
    */
   mouseProto._mouseInit = function () {
-    
+
     var self = this;
 
     // Delegate the touch handlers to the widget's element
@@ -163,7 +156,7 @@
    * Remove the touch event handlers
    */
   mouseProto._mouseDestroy = function () {
-    
+
     var self = this;
 
     // Delegate the touch handlers to the widget's element


### PR DESCRIPTION
Previously the event was created by using docuemtn.createEvent(), and initMouseEvent(); and it is deprecated. MouseEvent constructor is used to solve the issue.